### PR TITLE
feat: when-global-has-class.

### DIFF
--- a/lib/globalSelectors.scss
+++ b/lib/globalSelectors.scss
@@ -1,0 +1,11 @@
+@import "rootSelectors";
+
+@mixin when-global-has-class($class-name) {
+  :global {
+    @include when-root-has-class($class-name)
+  }
+
+  :local {
+    @content
+  }
+}


### PR DESCRIPTION
Switches search scope to global, uses when-root-has-class selector
and switches back to local scope to apply the style.

It can be solved also in another approach: Using parent selector.
But still the switch to global and back to local is mandatory because css modules changes the selector name.

Example to the other approach (which I think is less readable and less generic if wanted to use also other scss-root-selectors api):

`.my-feature-selector {
      //some css

      :global .some-global-selector :local & {
         //custom css
      }
}
`

If you want to include the ability of "when-global-..." In the library, it should be easy to have a "when-global-..." for every "when-root-...", and I'll do it in another pull request.
